### PR TITLE
readme link to QMK changed, readme text changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Meishi - The micro macro keyboard.**
 
-The micro macro keyboard which has only four keys for self made keyboard beginners. 
+The 4-key micro macro keyboard for self-made keyboard beginners.
 
 ![Meishi](https://raw.githubusercontent.com/Biacco42/meishi/readme/readme_image/P1210037.JPG)
 
@@ -13,37 +13,38 @@ The micro macro keyboard which has only four keys for self made keyboard beginne
 - **4** 1N4148 diodes
 - **4** [Switches of your choice](https://mechanicalkeyboards.com/shop/index.php?l=product_list&c=107)
 - **1** Tact switch
-- **4** Cushion rubber
+- **4** Rubber pads
 
 ## Mount the Diodes
 
-**Double check your work**. Black lines should be facing the square pad.
+Meishi PCB is symmetrical. The side with the logo is the top.
+**Double check your work**. Black lines must be facing the square pad.
 
 ## Mount switches
 
-Mount switches on PCB.
+Mount switches on the top side of the PCB.
 
 ## Mount the Pro Micro
 
-Meishi PCB is symmetrical. The PCB logo side up, mount Pro Micro upside up.
+Mount the Pro Micro on the top side of the PCB with the Pro Micro's USB facing up. (Please refer to the image)
 
-## Attach cushion rubber
+## Attach rubber pads
 
-Attach cushion rubber on PCB buttom side.
+Attach the rubber pads on the bottom side of the PCB.
 
 ## Flash QMK Firmware
 
-QMK firmware for Meishi now abilable on [this repo at meishi branch](https://github.com/Biacco42/qmk_firmware/tree/meishi).
-This document doesn't cover how to build QMK. Prease refer to [QMK documents](https://docs.qmk.fm/).
+QMK firmware for Meishi is available in [this repo on the meishi branch](https://github.com/Biacco42/qmk_firmware/tree/master/keyboards/meishi).
+This readme document does not cover how to build QMK. Please refer to the [QMK documents](https://docs.qmk.fm/).
 
-Conntect the keyboard by usb cable to PC and run
+Connect the keyboard to the PC via USB and run the following:
 
 ```
 $ make meishi:default:avrdude
 ```
 
-will build and try to flash your firmware. Follow the instractions that require to reset the Pro Micro.
+It will build and try to flash your firmware. Follow the instructions that require to reset the Pro Micro.
 
-This process may require privileges.
+This process may require elevated privileges.
 
-## All have done
+## You're all done!


### PR DESCRIPTION
I bought two of these Meishis last night and saw that one of the links in the readme wasn't working, so I found the updated url and added that. I also changed some of the wording, but would like confirmation if it is correct.

Also, what do you think about changing "https://mechanicalkeyboards.com/shop/index.php?l=product_list&c=107" to "https://yushakobo.jp/product-category/switches/"?

昨日の夜にメイシを二枚買ってreadmeの中のリンクは４０４が発見したのでそのリンクを変更しました。ちょっと英語を変更したけど正しく情報を表すかどうか確認したいでございます。

ちなみに、readmeのスイッチについてリンクはhttps://mechanicalkeyboards.com/shop/index.php?l=product_list&c=107　から　https://yushakobo.jp/product-category/switches/　にしたらどうだと思いますか？ w